### PR TITLE
"Repeat group picker" UI for FormHierarchy

### DIFF
--- a/collect_app/src/androidTest/assets/forms/formNavigationTestForms/nested-repeats.xml
+++ b/collect_app/src/androidTest/assets/forms/formNavigationTestForms/nested-repeats.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0"?>
+<h:html xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml"
+    xmlns:jr="http://openrosa.org/javarosa" xmlns:odk="http://www.opendatakit.org/xforms"
+    xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns="http://www.w3.org/2002/xforms">
+    <h:head>
+        <h:title>nested-repeats</h:title>
+        <model>
+            <instance>
+                <nested-repeats id="nested-repeats">
+                    <intro />
+                    <friends_intro />
+                    <friends jr:template="">
+                        <friends_label>
+                            <friend_count />
+                            <friend_name />
+                            <pets_intro />
+                            <pets jr:template="">
+                                <pets_label>
+                                    <pet_count />
+                                    <pet_name />
+                                </pets_label>
+                            </pets>
+                        </friends_label>
+                    </friends>
+                    <enemies jr:template="">
+                        <enemies_label>
+                            <enemy_count />
+                            <enemy_name />
+                        </enemies_label>
+                    </enemies>
+                    <meta>
+                        <instanceID />
+                    </meta>
+                </nested-repeats>
+            </instance>
+            <bind nodeset="/nested-repeats/intro" readonly="true()" type="string" />
+            <bind nodeset="/nested-repeats/friends_intro" readonly="true()" type="string" />
+            <bind calculate="position(../..)" nodeset="/nested-repeats/friends/friends_label/friend_count"
+                type="string" />
+            <bind nodeset="/nested-repeats/friends/friends_label/friend_name" type="string" />
+            <bind nodeset="/nested-repeats/friends/friends_label/pets_intro" readonly="true()" type="string" />
+            <bind calculate="position(../..)"
+                nodeset="/nested-repeats/friends/friends_label/pets/pets_label/pet_count" type="string" />
+            <bind nodeset="/nested-repeats/friends/friends_label/pets/pets_label/pet_name" type="string" />
+            <bind calculate="position(../..)" nodeset="/nested-repeats/enemies/enemies_label/enemy_count"
+                type="string" />
+            <bind nodeset="/nested-repeats/enemies/enemies_label/enemy_name" type="string" />
+            <bind calculate="concat('uuid:', uuid())" nodeset="/nested-repeats/meta/instanceID"
+                readonly="true()" type="string" />
+        </model>
+    </h:head>
+    <h:body>
+        <input ref="/nested-repeats/intro">
+            <label>This form demonstrates the use of nested groups in repeats to provide labels for those repeats. It's
+                also useful for testing nested repeats.
+            </label>
+        </input>
+        <input ref="/nested-repeats/friends_intro">
+            <label>You will now be asked questions about your friends. When you see a dialog, tap "Add" until you have
+                added all your friends.
+            </label>
+        </input>
+        <group ref="/nested-repeats/friends">
+            <label>Friends</label>
+            <repeat nodeset="/nested-repeats/friends">
+                <group ref="/nested-repeats/friends/friends_label">
+                    <label>
+                        <output value=" /nested-repeats/friends/friends_label/friend_name " />
+                    </label>
+                    <input ref="/nested-repeats/friends/friends_label/friend_name">
+                        <label>What is friend #<output
+                            value=" /nested-repeats/friends/friends_label/friend_count " />'s name?
+                        </label>
+                    </input>
+                    <input ref="/nested-repeats/friends/friends_label/pets_intro">
+                        <label>You will now be asked questions about<output
+                            value=" /nested-repeats/friends/friends_label/friend_name " />'s pets. When you see
+                            a dialog, tap &quot;Add&quot; until you have added all of<output
+                                value=" /nested-repeats/friends/friends_label/friend_name " />'s pets.
+                        </label>
+                    </input>
+                    <group ref="/nested-repeats/friends/friends_label/pets">
+                        <label>Pets</label>
+                        <repeat nodeset="/nested-repeats/friends/friends_label/pets">
+                            <group ref="/nested-repeats/friends/friends_label/pets/pets_label">
+                                <label>
+                                    <output
+                                        value=" /nested-repeats/friends/friends_label/pets/pets_label/pet_name " />
+                                </label>
+                                <input ref="/nested-repeats/friends/friends_label/pets/pets_label/pet_name">
+                                    <label>What is the name of<output
+                                        value=" /nested-repeats/friends/friends_label/friend_name " />'s pet #
+                                        <output
+                                            value=" /nested-repeats/friends/friends_label/pets/pets_label/pet_count " />
+                                        ?
+                                    </label>
+                                </input>
+                            </group>
+                        </repeat>
+                    </group>
+                </group>
+            </repeat>
+        </group>
+        <group ref="/nested-repeats/enemies">
+            <label>Enemies</label>
+            <repeat nodeset="/nested-repeats/enemies">
+                <group ref="/nested-repeats/enemies/enemies_label">
+                    <label>
+                        <output value=" /nested-repeats/enemies/enemies_label/enemy_name " />
+                    </label>
+                    <input ref="/nested-repeats/enemies/enemies_label/enemy_name">
+                        <label>What is enemy #<output
+                            value=" /nested-repeats/enemies/enemies_label/enemy_count " />'s name?
+                        </label>
+                    </input>
+                </group>
+            </repeat>
+        </group>
+    </h:body>
+</h:html>

--- a/collect_app/src/androidTest/java/org/odk/collect/android/activities/FormHierarchyActivityTest.java
+++ b/collect_app/src/androidTest/java/org/odk/collect/android/activities/FormHierarchyActivityTest.java
@@ -1,0 +1,85 @@
+package org.odk.collect.android.activities;
+
+import android.Manifest;
+import android.content.Context;
+import android.content.Intent;
+import android.content.res.AssetManager;
+import android.os.Environment;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.espresso.intent.rule.IntentsTestRule;
+import android.support.test.rule.GrantPermissionRule;
+import android.support.test.runner.AndroidJUnit4;
+import org.apache.commons.io.IOUtils;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import tools.fastlane.screengrab.Screengrab;
+import tools.fastlane.screengrab.UiAutomatorScreenshotStrategy;
+
+import java.io.*;
+
+/**
+ * Integration test that runs through FormHierarchy behavior.
+ */
+@RunWith(AndroidJUnit4.class)
+public class FormHierarchyActivityTest {
+
+    private static final String NESTED_REPEATS_FORM = "nested-repeats.xml";
+    private static final String FORMS_DIRECTORY = "/odk/forms/";
+
+    @Rule
+    public FormEntryActivityTestRule activityTestRule = new FormEntryActivityTestRule();
+
+    @Rule
+    public GrantPermissionRule permissionRule = GrantPermissionRule.grant(Manifest.permission.READ_EXTERNAL_STORAGE, Manifest.permission.WRITE_EXTERNAL_STORAGE);
+
+    @BeforeClass
+    public static void copyFormToSdCard() throws IOException {
+        String pathname = getFormPath();
+        if (new File(pathname).exists()) {
+            return;
+        }
+
+        AssetManager assetManager = InstrumentationRegistry.getContext().getAssets();
+        InputStream inputStream = assetManager.open(NESTED_REPEATS_FORM);
+
+        File outFile = new File(pathname);
+        OutputStream outputStream = new FileOutputStream(outFile);
+
+        IOUtils.copy(inputStream, outputStream);
+    }
+
+    @BeforeClass
+    public static void beforeAll() {
+        Screengrab.setDefaultScreenshotStrategy(new UiAutomatorScreenshotStrategy());
+    }
+
+    @Test
+    public void testSomething() {
+        // TODO: 1. Load the form (launch FormEntryActivity first with EXTRA_TESTING_PATH?).
+        // TODO: 2. Navigate around using helpers.
+        // TODO: 3. Test with screenshots and assertions.
+    }
+
+    // --- Helpers
+
+    private static String getFormPath() {
+        return Environment.getExternalStorageDirectory().getPath()
+                + FORMS_DIRECTORY
+                + NESTED_REPEATS_FORM;
+    }
+
+    private class FormEntryActivityTestRule extends IntentsTestRule<FormEntryActivity> {
+
+        FormEntryActivityTestRule() {
+            super(FormEntryActivity.class);
+        }
+
+        @Override
+        protected Intent getActivityIntent() {
+            Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+            return new Intent(context, FormEntryActivity.class);
+        }
+    }
+}

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -103,8 +103,6 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
     /**
      * The index of the question that is being displayed in the hierarchy. On first launch, it is
      * the same as {@link #startIndex}. It can then become the index of a repeat instance.
-     * TODO: Is keeping this as a field necessary? I believe what it is used for is to send the user
-     * to edit a question that caused an error in the hierarchy.
      */
     private FormIndex currentIndex;
 
@@ -287,7 +285,8 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
         try {
             FormController formController = Collect.getInstance().getFormController();
 
-            // Record the current index so we can return to the same place if the user hits 'back'.
+            // Save the current index so we can return to the problematic question
+            // in the event of an error.
             currentIndex = formController.getFormIndex();
 
             elementsToDisplay = new ArrayList<>();

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -415,28 +415,14 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
 
         switch (element.getType()) {
             case EXPANDED:
-                element.setType(HierarchyElement.Type.COLLAPSED);
-                ArrayList<HierarchyElement> children = element.getChildren();
-                for (int i = 0; i < children.size(); i++) {
-                    elementsToDisplay.remove(position + 1);
-                }
-                element.setIcon(ContextCompat.getDrawable(this, R.drawable.expander_ic_minimized));
-                break;
             case COLLAPSED:
-                element.setType(HierarchyElement.Type.EXPANDED);
-                ArrayList<HierarchyElement> children1 = element.getChildren();
-                for (int i = 0; i < children1.size(); i++) {
-                    Timber.i("adding child: %s", children1.get(i).getFormIndex());
-                    elementsToDisplay.add(position + 1 + i, children1.get(i));
-
-                }
-                element.setIcon(ContextCompat.getDrawable(this, R.drawable.expander_ic_maximized));
+                refreshView();
                 break;
             case QUESTION:
                 onQuestionClicked(index);
                 return;
             case CHILD:
-                Collect.getInstance().getFormController().jumpToIndex(element.getFormIndex());
+                Collect.getInstance().getFormController().jumpToIndex(index);
                 setResult(RESULT_OK);
                 refreshView();
                 return;

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -313,6 +313,10 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
         return formController.getFormIndex().getReference().getParentRef().toString(true);
     }
 
+    private String getUnindexedGroupRef(FormController formController) {
+        return getUnindexedGroupRef(formController.getFormIndex());
+    }
+
     private String getUnindexedGroupRef(FormIndex index) {
         return index.getReference().toString(false);
     }
@@ -374,6 +378,7 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
 
                 // get the ref to this element
                 String currentRef = getGroupRef(formController);
+                String currentUnindexedRef = getUnindexedGroupRef(formController);
 
                 // retrieve the current group
                 String curGroup = (repeatGroupRef == null) ? contextGroupRef : repeatGroupRef;
@@ -437,7 +442,7 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
                         if (shouldShowRepeatGroupPicker) {
                             // Don't render other groups' children.
                             String repeatGroupPickerRef = getUnindexedGroupRef(repeatGroupPickerIndex);
-                            if (!repeatGroupRef.startsWith(repeatGroupPickerRef)) {
+                            if (!currentUnindexedRef.startsWith(repeatGroupPickerRef)) {
                                 break;
                             }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -106,6 +106,12 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
      */
     private FormIndex currentIndex;
 
+    /**
+     * The index of the screen that is being displayed in the hierarchy
+     * (either the root of the form or a repeat group).
+     */
+    private FormIndex screenIndex;
+
     protected Button jumpPreviousButton;
     protected Button jumpBeginningButton;
     protected Button jumpEndButton;
@@ -192,12 +198,18 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
     }
 
     protected void goUpLevel() {
+        FormController formController = Collect.getInstance().getFormController();
         boolean shouldShowRepeatGroupPicker = repeatGroupPickerRef != null;
 
         if (shouldShowRepeatGroupPicker) {
             // Simply exit the picker.
             repeatGroupPickerRef = null;
         } else {
+            // Toggle the picker if coming from an inner repeat group.
+            if (formController.getEvent(screenIndex) == FormEntryController.EVENT_REPEAT) {
+                repeatGroupPickerRef = getUnindexedGroupRef(screenIndex);
+            }
+
             Collect.getInstance().getFormController().stepToOuterScreenEvent();
         }
 
@@ -233,6 +245,9 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
         // display everything enclosed within that group.
         contextGroupRef = "";
 
+        // Save the index to the screen itself, before potentially moving into it.
+        screenIndex = startIndex;
+
         // If we're currently at a repeat node, record the name of the node and step to the next
         // node to display.
         if (formController.getEvent() == FormEntryController.EVENT_REPEAT) {
@@ -244,6 +259,9 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
             while (!isScreenEvent(formController, potentialStartIndex)) {
                 potentialStartIndex = formController.stepIndexOut(potentialStartIndex);
             }
+
+            screenIndex = potentialStartIndex;
+
             if (potentialStartIndex == null) {
                 // check to see if the question is at the first level of the hierarchy. If it
                 // is, display the root level from the beginning.

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -462,7 +462,7 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
                             // Display the repeat header for the group.
                             HierarchyElement group = new HierarchyElement(
                                     getLabel(fc), getString(R.string.repeatable_group_label),
-                                    null, HierarchyElement.Type.COLLAPSED, fc.getIndex());
+                                    null, HierarchyElement.Type.PARENT, fc.getIndex());
                             elementsToDisplay.add(group);
                         }
 
@@ -494,14 +494,13 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
         FormIndex index = element.getFormIndex();
 
         switch (element.getType()) {
-            case EXPANDED:
-            case COLLAPSED:
-                repeatGroupPickerIndex = index;
-                refreshView();
-                break;
             case QUESTION:
                 onQuestionClicked(index);
                 return;
+            case PARENT:
+                repeatGroupPickerIndex = index;
+                refreshView();
+                break;
             case CHILD:
                 repeatGroupPickerIndex = null;
                 Collect.getInstance().getFormController().jumpToIndex(index);

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -326,21 +326,19 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
             jumpToHierarchyStartIndex();
 
             int event = formController.getEvent();
+
             if (event == FormEntryController.EVENT_BEGINNING_OF_FORM) {
-                // The beginning of form has no valid prompt to display.
                 formController.stepToNextEvent(FormController.STEP_INTO_GROUP);
                 contextGroupRef = getParentGroupRef(formController);
+            }
+
+            if (event == FormEntryController.EVENT_BEGINNING_OF_FORM && !shouldShowRepeatGroupPicker) {
+                // The beginning of form has no valid prompt to display.
                 groupPathTextView.setVisibility(View.GONE);
                 jumpPreviousButton.setEnabled(false);
             } else {
                 groupPathTextView.setVisibility(View.VISIBLE);
                 groupPathTextView.setText(getCurrentPath());
-                jumpPreviousButton.setEnabled(true);
-            }
-
-            // We might be at the beginning FormIndex, but if showing the picker,
-            // you always need to be able to go up.
-            if (shouldShowRepeatGroupPicker) {
                 jumpPreviousButton.setEnabled(true);
             }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -22,6 +22,7 @@ import android.support.v7.widget.DividerItemDecoration;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.Toolbar;
+import android.text.TextUtils;
 import android.view.KeyEvent;
 import android.view.View;
 import android.widget.Button;
@@ -217,7 +218,7 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
     }
 
     /**
-     * Builds a string representing the path of the current group. Each level is separated by a <.
+     * Builds a string representing the path of the current group. Each level is separated by `>`.
      */
     private String getCurrentPath() {
         FormController formController = Collect.getInstance().getFormController();
@@ -230,7 +231,17 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
             groups.add(0, formController.getCaptionPrompt(index));
             index = formController.stepIndexOut(index);
         }
-        return ODKView.getGroupsPath(groups.toArray(new FormEntryCaption[groups.size()]));
+
+        String path = ODKView.getGroupsPath(groups.toArray(new FormEntryCaption[groups.size()]));
+
+        boolean shouldShowRepeatGroupPicker = repeatGroupPickerIndex != null;
+        if (shouldShowRepeatGroupPicker) {
+            FormEntryCaption fc = formController.getCaptionPrompt(repeatGroupPickerIndex);
+            String label = getLabel(fc);
+            return TextUtils.isEmpty(path) ? label : path + " > " + label;
+        } else {
+            return path;
+        }
     }
 
     /**

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -198,14 +198,20 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
         });
     }
 
+    /**
+     * Navigates "up" in the form hierarchy.
+     */
     protected void goUpLevel() {
         FormController formController = Collect.getInstance().getFormController();
 
+        // If `repeatGroupPickerIndex` is set it means we're currently displaying
+        // a list of repeat instances. If we unset `repeatGroupPickerIndex`,
+        // we will go back up to the previous screen.
         if (shouldShowRepeatGroupPicker()) {
-            // Simply exit the picker.
+            // Exit the picker.
             repeatGroupPickerIndex = null;
         } else {
-            // Toggle the picker if coming from an inner repeat group.
+            // Enter the picker if coming from a repeat group.
             if (formController.getEvent(screenIndex) == FormEntryController.EVENT_REPEAT) {
                 repeatGroupPickerIndex = screenIndex;
             }

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -87,6 +87,14 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
     private String contextGroupRef;
 
     /**
+     * The ref to the repeat group we want to render children for.
+     *
+     * If this is non-null, we will render an intermediary "picker" view
+     * showing the children of the given repeat group.
+     */
+    private String repeatGroupPickerRef;
+
+    /**
      * The index of the question or the field list the FormController was set to when the hierarchy
      * was accessed. Used to jump the user back to where they were if applicable.
      */
@@ -259,6 +267,10 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
         return formController.getFormIndex().getReference().getParentRef().toString(true);
     }
 
+    private String getUnindexedGroupRef(FormIndex index) {
+        return index.getReference().toString(false);
+    }
+
     /**
      * Rebuilds the view to reflect the elements that should be displayed based on the
      * FormController's current index. This index is either set prior to the activity opening or
@@ -272,6 +284,8 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
             currentIndex = formController.getFormIndex();
 
             elementsToDisplay = new ArrayList<>();
+
+            boolean shouldShowRepeatGroupPicker = repeatGroupPickerRef != null;
 
             jumpToHierarchyStartIndex(currentIndex);
 
@@ -334,6 +348,9 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
 
                 switch (event) {
                     case FormEntryController.EVENT_QUESTION:
+                        if (shouldShowRepeatGroupPicker) {
+                            break;
+                        }
 
                         FormEntryPrompt fp = formController.getQuestionPrompt();
                         String label = getLabel(fp);
@@ -366,7 +383,25 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
                         // Only the [0] emits the repeat header.
                         // Every one displays the descend-into action element.
 
-                        if (fc.getMultiplicity() == 0) {
+                        if (shouldShowRepeatGroupPicker) {
+                            // Don't render other groups' children.
+                            if (!repeatGroupRef.startsWith(repeatGroupPickerRef)) {
+                                break;
+                            }
+
+                            String repeatLabel = getLabel(fc);
+                            if (fc.getFormElement().getChildren().size() == 1 && fc.getFormElement().getChild(0) instanceof GroupDef) {
+                                formController.stepToNextEvent(FormController.STEP_INTO_GROUP);
+                                FormEntryCaption fc2 = formController.getCaptionPrompt();
+                                if (getLabel(fc2) != null) {
+                                    repeatLabel = getLabel(fc2);
+                                }
+                            }
+                            repeatLabel += " (" + (fc.getMultiplicity() + 1) + ")\u200E";
+
+                            HierarchyElement childElement = new HierarchyElement(repeatLabel, null, null, HierarchyElement.Type.CHILD, fc.getIndex());
+                            elementsToDisplay.add(childElement);
+                        } else if (fc.getMultiplicity() == 0) {
                             // Display the repeat header for the group.
                             HierarchyElement group =
                                     new HierarchyElement(getLabel(fc), null, ContextCompat
@@ -374,18 +409,7 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
                                             HierarchyElement.Type.COLLAPSED, fc.getIndex());
                             elementsToDisplay.add(group);
                         }
-                        String repeatLabel = getLabel(fc);
-                        if (fc.getFormElement().getChildren().size() == 1 && fc.getFormElement().getChild(0) instanceof GroupDef) {
-                            formController.stepToNextEvent(FormController.STEP_INTO_GROUP);
-                            FormEntryCaption fc2 = formController.getCaptionPrompt();
-                            if (getLabel(fc2) != null) {
-                                repeatLabel = getLabel(fc2);
-                            }
-                        }
-                        repeatLabel += " (" + (fc.getMultiplicity() + 1) + ")\u200E";
-                        // Add this group name to the drop down list for this repeating group.
-                        HierarchyElement h = elementsToDisplay.get(elementsToDisplay.size() - 1);
-                        h.addChild(new HierarchyElement(repeatLabel, null, null, HierarchyElement.Type.CHILD, fc.getIndex()));
+
                         break;
                 }
                 event =
@@ -416,12 +440,14 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
         switch (element.getType()) {
             case EXPANDED:
             case COLLAPSED:
+                repeatGroupPickerRef = getUnindexedGroupRef(index);
                 refreshView();
                 break;
             case QUESTION:
                 onQuestionClicked(index);
                 return;
             case CHILD:
+                repeatGroupPickerRef = null;
                 Collect.getInstance().getFormController().jumpToIndex(index);
                 setResult(RESULT_OK);
                 refreshView();

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -222,10 +222,12 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
     }
 
     /**
-     * Finds the start of this hierarchy view based on where the user came from.
+     * Goes to the start of the hierarchy view based on where the user came from.
+     * Backs out until the index is at the beginning of a repeat group or the beginning of the form.
      */
-    private void jumpToHierarchyStartIndex(FormIndex startIndex) {
+    private void jumpToHierarchyStartIndex() {
         FormController formController = Collect.getInstance().getFormController();
+        FormIndex startIndex = formController.getFormIndex();
 
         // If we're not at the first level, we're inside a repeated group so we want to only
         // display everything enclosed within that group.
@@ -238,10 +240,8 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
             formController.stepToNextEvent(FormController.STEP_INTO_GROUP);
         } else {
             FormIndex potentialStartIndex = formController.stepIndexOut(startIndex);
-            // If we have a 'group' tag, we want to step back until we hit a repeat or the
-            // beginning.
-            while (potentialStartIndex != null
-                    && formController.getEvent(potentialStartIndex) == FormEntryController.EVENT_GROUP) {
+            // Step back until we hit a repeat or the beginning.
+            while (!isScreenEvent(formController, potentialStartIndex)) {
                 potentialStartIndex = formController.stepIndexOut(potentialStartIndex);
             }
             if (potentialStartIndex == null) {
@@ -262,6 +262,18 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
                 formController.stepToNextEvent(FormController.STEP_INTO_GROUP);
             }
         }
+    }
+
+    /**
+     * Returns true if the event is an enclosing repeat or the start of the form.
+     * See {@link FormController#stepToOuterScreenEvent} for more context.
+     */
+    private boolean isScreenEvent(FormController formController, FormIndex index) {
+        // Beginning of form.
+        if (index == null) return true;
+
+        int event = formController.getEvent(index);
+        return event == FormEntryController.EVENT_REPEAT;
     }
 
     private String getGroupRef(FormController formController) {
@@ -293,7 +305,7 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
 
             boolean shouldShowRepeatGroupPicker = repeatGroupPickerRef != null;
 
-            jumpToHierarchyStartIndex(currentIndex);
+            jumpToHierarchyStartIndex();
 
             int event = formController.getEvent();
             if (event == FormEntryController.EVENT_BEGINNING_OF_FORM) {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -87,12 +87,12 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
     private String contextGroupRef;
 
     /**
-     * The ref to the repeat group we want to render children for.
+     * The index of the repeat group we want to render children for.
      *
      * If this is non-null, we will render an intermediary "picker" view
      * showing the children of the given repeat group.
      */
-    private String repeatGroupPickerRef;
+    private FormIndex repeatGroupPickerIndex;
 
     /**
      * The index of the question or the field list the FormController was set to when the hierarchy
@@ -199,15 +199,15 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
 
     protected void goUpLevel() {
         FormController formController = Collect.getInstance().getFormController();
-        boolean shouldShowRepeatGroupPicker = repeatGroupPickerRef != null;
+        boolean shouldShowRepeatGroupPicker = repeatGroupPickerIndex != null;
 
         if (shouldShowRepeatGroupPicker) {
             // Simply exit the picker.
-            repeatGroupPickerRef = null;
+            repeatGroupPickerIndex = null;
         } else {
             // Toggle the picker if coming from an inner repeat group.
             if (formController.getEvent(screenIndex) == FormEntryController.EVENT_REPEAT) {
-                repeatGroupPickerRef = getUnindexedGroupRef(screenIndex);
+                repeatGroupPickerIndex = screenIndex;
             }
 
             Collect.getInstance().getFormController().stepToOuterScreenEvent();
@@ -321,7 +321,7 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
 
             elementsToDisplay = new ArrayList<>();
 
-            boolean shouldShowRepeatGroupPicker = repeatGroupPickerRef != null;
+            boolean shouldShowRepeatGroupPicker = repeatGroupPickerIndex != null;
 
             jumpToHierarchyStartIndex();
 
@@ -425,6 +425,7 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
 
                         if (shouldShowRepeatGroupPicker) {
                             // Don't render other groups' children.
+                            String repeatGroupPickerRef = getUnindexedGroupRef(repeatGroupPickerIndex);
                             if (!repeatGroupRef.startsWith(repeatGroupPickerRef)) {
                                 break;
                             }
@@ -480,14 +481,14 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
         switch (element.getType()) {
             case EXPANDED:
             case COLLAPSED:
-                repeatGroupPickerRef = getUnindexedGroupRef(index);
+                repeatGroupPickerIndex = index;
                 refreshView();
                 break;
             case QUESTION:
                 onQuestionClicked(index);
                 return;
             case CHILD:
-                repeatGroupPickerRef = null;
+                repeatGroupPickerIndex = null;
                 Collect.getInstance().getFormController().jumpToIndex(index);
                 setResult(RESULT_OK);
                 refreshView();

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -200,9 +200,8 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
 
     protected void goUpLevel() {
         FormController formController = Collect.getInstance().getFormController();
-        boolean shouldShowRepeatGroupPicker = repeatGroupPickerIndex != null;
 
-        if (shouldShowRepeatGroupPicker) {
+        if (shouldShowRepeatGroupPicker()) {
             // Simply exit the picker.
             repeatGroupPickerIndex = null;
         } else {
@@ -234,8 +233,7 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
 
         String path = ODKView.getGroupsPath(groups.toArray(new FormEntryCaption[groups.size()]));
 
-        boolean shouldShowRepeatGroupPicker = repeatGroupPickerIndex != null;
-        if (shouldShowRepeatGroupPicker) {
+        if (shouldShowRepeatGroupPicker()) {
             FormEntryCaption fc = formController.getCaptionPrompt(repeatGroupPickerIndex);
             String label = getLabel(fc);
             return TextUtils.isEmpty(path) ? label : path + " > " + label;
@@ -321,6 +319,10 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
         return index.getReference().toString(false);
     }
 
+    private boolean shouldShowRepeatGroupPicker() {
+        return repeatGroupPickerIndex != null;
+    }
+
     /**
      * Rebuilds the view to reflect the elements that should be displayed based on the
      * FormController's current index. This index is either set prior to the activity opening or
@@ -336,8 +338,6 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
 
             elementsToDisplay = new ArrayList<>();
 
-            boolean shouldShowRepeatGroupPicker = repeatGroupPickerIndex != null;
-
             jumpToHierarchyStartIndex();
 
             int event = formController.getEvent();
@@ -347,7 +347,7 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
                 contextGroupRef = getParentGroupRef(formController);
             }
 
-            if (event == FormEntryController.EVENT_BEGINNING_OF_FORM && !shouldShowRepeatGroupPicker) {
+            if (event == FormEntryController.EVENT_BEGINNING_OF_FORM && !shouldShowRepeatGroupPicker()) {
                 // The beginning of form has no valid prompt to display.
                 groupPathTextView.setVisibility(View.GONE);
                 jumpPreviousButton.setEnabled(false);
@@ -404,7 +404,7 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
 
                 switch (event) {
                     case FormEntryController.EVENT_QUESTION:
-                        if (shouldShowRepeatGroupPicker) {
+                        if (shouldShowRepeatGroupPicker()) {
                             break;
                         }
 
@@ -439,7 +439,7 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
                         // Only the [0] emits the repeat header.
                         // Every one displays the descend-into action element.
 
-                        if (shouldShowRepeatGroupPicker) {
+                        if (shouldShowRepeatGroupPicker()) {
                             // Don't render other groups' children.
                             String repeatGroupPickerRef = getUnindexedGroupRef(repeatGroupPickerIndex);
                             if (!currentUnindexedRef.startsWith(repeatGroupPickerRef)) {

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -460,10 +460,9 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
                             elementsToDisplay.add(childElement);
                         } else if (fc.getMultiplicity() == 0) {
                             // Display the repeat header for the group.
-                            HierarchyElement group =
-                                    new HierarchyElement(getLabel(fc), null, ContextCompat
-                                            .getDrawable(this, R.drawable.expander_ic_minimized),
-                                            HierarchyElement.Type.COLLAPSED, fc.getIndex());
+                            HierarchyElement group = new HierarchyElement(
+                                    getLabel(fc), getString(R.string.repeatable_group_label),
+                                    null, HierarchyElement.Type.COLLAPSED, fc.getIndex());
                             elementsToDisplay.add(group);
                         }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -194,7 +194,14 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
     }
 
     protected void goUpLevel() {
-        Collect.getInstance().getFormController().stepToOuterScreenEvent();
+        boolean shouldShowRepeatGroupPicker = repeatGroupPickerRef != null;
+
+        if (shouldShowRepeatGroupPicker) {
+            // Simply exit the picker.
+            repeatGroupPickerRef = null;
+        } else {
+            Collect.getInstance().getFormController().stepToOuterScreenEvent();
+        }
 
         refreshView();
     }
@@ -299,6 +306,12 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
             } else {
                 groupPathTextView.setVisibility(View.VISIBLE);
                 groupPathTextView.setText(getCurrentPath());
+                jumpPreviousButton.setEnabled(true);
+            }
+
+            // We might be at the beginning FormIndex, but if showing the picker,
+            // you always need to be able to go up.
+            if (shouldShowRepeatGroupPicker) {
                 jumpPreviousButton.setEnabled(true);
             }
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -81,6 +81,12 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
     private TextView groupPathTextView;
 
     /**
+     * A ref to the current context group.
+     * Useful to make sure we only render items inside of the group.
+     */
+    private String contextGroupRef;
+
+    /**
      * The index of the question or the field list the FormController was set to when the hierarchy
      * was accessed. Used to jump the user back to where they were if applicable.
      */
@@ -203,6 +209,57 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
     }
 
     /**
+     * Finds the start of this hierarchy view based on where the user came from.
+     */
+    private void jumpToHierarchyStartIndex(FormIndex startIndex) {
+        FormController formController = Collect.getInstance().getFormController();
+
+        // If we're not at the first level, we're inside a repeated group so we want to only
+        // display everything enclosed within that group.
+        contextGroupRef = "";
+
+        // If we're currently at a repeat node, record the name of the node and step to the next
+        // node to display.
+        if (formController.getEvent() == FormEntryController.EVENT_REPEAT) {
+            contextGroupRef = getGroupRef(formController);
+            formController.stepToNextEvent(FormController.STEP_INTO_GROUP);
+        } else {
+            FormIndex potentialStartIndex = formController.stepIndexOut(startIndex);
+            // If we have a 'group' tag, we want to step back until we hit a repeat or the
+            // beginning.
+            while (potentialStartIndex != null
+                    && formController.getEvent(potentialStartIndex) == FormEntryController.EVENT_GROUP) {
+                potentialStartIndex = formController.stepIndexOut(potentialStartIndex);
+            }
+            if (potentialStartIndex == null) {
+                // check to see if the question is at the first level of the hierarchy. If it
+                // is, display the root level from the beginning.
+                formController.jumpToIndex(FormIndex.createBeginningOfFormIndex());
+            } else {
+                // otherwise we're at a repeated group
+                formController.jumpToIndex(potentialStartIndex);
+            }
+
+            int event = formController.getEvent();
+
+            // now test again for repeat. This should be true at this point or we're at the
+            // beginning
+            if (event == FormEntryController.EVENT_REPEAT) {
+                contextGroupRef = getGroupRef(formController);
+                formController.stepToNextEvent(FormController.STEP_INTO_GROUP);
+            }
+        }
+    }
+
+    private String getGroupRef(FormController formController) {
+        return formController.getFormIndex().getReference().toString(true);
+    }
+
+    private String getParentGroupRef(FormController formController) {
+        return formController.getFormIndex().getReference().getParentRef().toString(true);
+    }
+
+    /**
      * Rebuilds the view to reflect the elements that should be displayed based on the
      * FormController's current index. This index is either set prior to the activity opening or
      * mutated by {@link #onElementClick(HierarchyElement)} if a repeat instance was tapped.
@@ -210,55 +267,19 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
     public void refreshView() {
         try {
             FormController formController = Collect.getInstance().getFormController();
+
             // Record the current index so we can return to the same place if the user hits 'back'.
             currentIndex = formController.getFormIndex();
 
-            // If we're not at the first level, we're inside a repeated group so we want to only
-            // display
-            // everything enclosed within that group.
-            String contextGroupRef = "";
             elementsToDisplay = new ArrayList<>();
 
-            // If we're currently at a repeat node, record the name of the node and step to the next
-            // node to display.
-            if (formController.getEvent() == FormEntryController.EVENT_REPEAT) {
-                contextGroupRef =
-                        formController.getFormIndex().getReference().toString(true);
-                formController.stepToNextEvent(FormController.STEP_INTO_GROUP);
-            } else {
-                FormIndex startTest = formController.stepIndexOut(currentIndex);
-                // If we have a 'group' tag, we want to step back until we hit a repeat or the
-                // beginning.
-                while (startTest != null
-                        && formController.getEvent(startTest) == FormEntryController.EVENT_GROUP) {
-                    startTest = formController.stepIndexOut(startTest);
-                }
-                if (startTest == null) {
-                    // check to see if the question is at the first level of the hierarchy. If it
-                    // is,
-                    // display the root level from the beginning.
-                    formController.jumpToIndex(FormIndex
-                            .createBeginningOfFormIndex());
-                } else {
-                    // otherwise we're at a repeated group
-                    formController.jumpToIndex(startTest);
-                }
-
-                // now test again for repeat. This should be true at this point or we're at the
-                // beginning
-                if (formController.getEvent() == FormEntryController.EVENT_REPEAT) {
-                    contextGroupRef =
-                            formController.getFormIndex().getReference().toString(true);
-                    formController.stepToNextEvent(FormController.STEP_INTO_GROUP);
-                }
-            }
+            jumpToHierarchyStartIndex(currentIndex);
 
             int event = formController.getEvent();
             if (event == FormEntryController.EVENT_BEGINNING_OF_FORM) {
                 // The beginning of form has no valid prompt to display.
                 formController.stepToNextEvent(FormController.STEP_INTO_GROUP);
-                contextGroupRef =
-                        formController.getFormIndex().getReference().getParentRef().toString(true);
+                contextGroupRef = getParentGroupRef(formController);
                 groupPathTextView.setVisibility(View.GONE);
                 jumpPreviousButton.setEnabled(false);
             } else {
@@ -287,7 +308,7 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
             while (event != FormEntryController.EVENT_END_OF_FORM) {
 
                 // get the ref to this element
-                String currentRef = formController.getFormIndex().getReference().toString(true);
+                String currentRef = getGroupRef(formController);
 
                 // retrieve the current group
                 String curGroup = (repeatGroupRef == null) ? contextGroupRef : repeatGroupRef;

--- a/collect_app/src/main/java/org/odk/collect/android/logic/HierarchyElement.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/HierarchyElement.java
@@ -28,12 +28,6 @@ import java.util.ArrayList;
  */
 public class HierarchyElement {
     /**
-     * Repeat instances (always of type {@link Type#CHILD}) if this element is a repeat
-     * ({@link Type#COLLAPSED} or {@link Type#EXPANDED}). Not relevant otherwise.
-     */
-    private final ArrayList<HierarchyElement> children = new ArrayList<>();
-
-    /**
      * The type and state of this element. See {@link Type}.
      */
     @NonNull
@@ -58,8 +52,7 @@ public class HierarchyElement {
     private final String secondaryText;
 
     /**
-     * The collapsed or expanded icon if this element is a repeat ({@link Type#COLLAPSED} or
-     * {@link Type#EXPANDED}). Not relevant otherwise.
+     * An optional icon.
      */
     @Nullable
     private Drawable icon;
@@ -106,14 +99,6 @@ public class HierarchyElement {
         type = newType;
     }
 
-    public ArrayList<HierarchyElement> getChildren() {
-        return children;
-    }
-
-    public void addChild(HierarchyElement h) {
-        children.add(h);
-    }
-
     /**
      * The type and state of this element.
      */
@@ -124,18 +109,13 @@ public class HierarchyElement {
         CHILD,
 
         /**
-         * A repeat that should be displayed as expanded.
+         * A repeat.
          */
-        EXPANDED,
-
-        /**
-         * A repeat that should be displayed as collapsed.
-         */
-        COLLAPSED,
+        PARENT,
 
         /**
          * A question.
          */
-        QUESTION;
+        QUESTION
     }
 }

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -116,6 +116,7 @@
     <string name="quit_application">Exit %s</string>
     <string name="quit_entry">Save Form and Exit</string>
     <string name="refresh">Refresh</string>
+    <string name="repeatable_group_label">Repeatable Group</string>
     <string name="replace_barcode">Replace Barcode</string>
     <string name="required_answer_error">Sorry, this response is required!</string>
     <string name="review_data">Edit Saved Form</string>


### PR DESCRIPTION
Implements the core behavior described in https://github.com/opendatakit/roadmap/issues/19. The new buttons will be added in a separate upcoming PR.

Based on branch https://github.com/opendatakit/collect/pull/2730.

![screenshot of new picker UI](https://user-images.githubusercontent.com/2047062/48794831-13d35a00-ecc9-11e8-900e-d2863e089244.png)

#### What has been done to verify that this works as intended?

Extensive manual testing with:
- [nested-repeats-complex](https://drive.google.com/open?id=1zOvDEZz6vwQr5IBT91k7MuDMZ-hJDats) (top-level "friends" and "enemies" groups; nested "friends/pets" group)
- [nested-repeats-complex-jr](https://drive.google.com/open?id=1j6LPDAb9keqpinge-onLBtgrqBhEWdAy) (same as above, but "enemies" has no `jr-template` tag)

Navigating in and out of nested repeat groups, adding children, editing names, using the back button, jumping back and forth between the FormEditor and FormHierarchy views.

#### Why is this the best possible solution? Were any other approaches considered?

We considered overhauling `FormHierarchyActivity` to navigate using a more conventional "back stack" instead of using `refreshView`, but that requires all method calls to be stateless to avoid corrupting the state of earlier activities, which `FormController` currently doesn't support. This simpler solution works within the existing event-based form parsing framework.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

This changes the navigational UI so that instead of expanding a dropdown showing the children of a repeatable group, those children are shown on their own on an intermediary screen (sometimes referred to as the "picker"). This intermediary screen will be used in an upcoming PR to display an "add" button to add new items to the repeat group. Overall these changes aim to improve the speed and intuitiveness of navigation.

The behavior changes should be isolated to FormHierarchyActivity, but this activity interacts with the global state via FormController, so regressions can be avoided by ensuring that the state is not mutated in some new unexpected way.

#### Do we need any specific form for testing your changes? If so, please attach one.

Linked above.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.

I was unable to find any existing documentation that needs to be changed (namely [here](https://docs.opendatakit.org/collect-filling-forms/#jumping-to-questions) which has screenshots of FormHierarchy but no expandable repeat groups).

#### Before submitting this PR, please make sure you have:
- [x] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)
