### PR TITLE
Clean up form 'breadcrumb' paths

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -239,8 +239,11 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
     private String getCurrentPath() {
         FormController formController = Collect.getInstance().getFormController();
         FormIndex index = formController.getFormIndex();
-        // move to enclosing group...
-        index = formController.stepIndexOut(index);
+
+        if (formController.getEvent(index) == FormEntryController.EVENT_QUESTION) {
+            // move to enclosing group...
+            index = formController.stepIndexOut(index);
+        }
 
         List<FormEntryCaption> groups = new ArrayList<>();
 

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -22,7 +22,6 @@ import android.support.v7.widget.DividerItemDecoration;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.Toolbar;
-import android.text.TextUtils;
 import android.view.View;
 import android.widget.Button;
 import android.widget.TextView;
@@ -234,7 +233,8 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
     }
 
     /**
-     * Builds a string representing the path of the current group. Each level is separated by `>`.
+     * Returns a string representing the 'path' of the current screen.
+     * Each level is separated by `>`.
      */
     private String getCurrentPath() {
         FormController formController = Collect.getInstance().getFormController();
@@ -243,20 +243,17 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
         index = formController.stepIndexOut(index);
 
         List<FormEntryCaption> groups = new ArrayList<>();
+
+        if (shouldShowRepeatGroupPicker()) {
+            groups.add(formController.getCaptionPrompt(repeatGroupPickerIndex));
+        }
+
         while (index != null) {
             groups.add(0, formController.getCaptionPrompt(index));
             index = formController.stepIndexOut(index);
         }
 
-        String path = ODKView.getGroupsPath(groups.toArray(new FormEntryCaption[groups.size()]));
-
-        if (shouldShowRepeatGroupPicker()) {
-            FormEntryCaption fc = formController.getCaptionPrompt(repeatGroupPickerIndex);
-            String label = getLabel(fc);
-            return TextUtils.isEmpty(path) ? label : path + " > " + label;
-        } else {
-            return path;
-        }
+        return ODKView.getGroupsPath(groups.toArray(new FormEntryCaption[groups.size()]));
     }
 
     /**

--- a/collect_app/src/main/java/org/odk/collect/android/views/ODKView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/ODKView.java
@@ -286,6 +286,10 @@ public class ODKView extends FrameLayout implements OnLongClickListener {
         }
     }
 
+    /**
+     * Builds a string representing the 'path' of the list of groups.
+     * Each level is separated by `>`.
+     */
     @NonNull
     public static String getGroupsPath(FormEntryCaption[] groups) {
         StringBuilder path = new StringBuilder("");

--- a/collect_app/src/main/java/org/odk/collect/android/views/ODKView.java
+++ b/collect_app/src/main/java/org/odk/collect/android/views/ODKView.java
@@ -296,6 +296,7 @@ public class ODKView extends FrameLayout implements OnLongClickListener {
         if (groups != null) {
             String longText;
             int multiplicity;
+            int nextMultiplicity = -1;
             int index = 1;
             // list all groups in one string
             for (FormEntryCaption group : groups) {
@@ -303,11 +304,17 @@ public class ODKView extends FrameLayout implements OnLongClickListener {
                 longText = group.getLongText();
                 if (longText != null) {
                     path.append(longText);
-                    if (group.repeats() && multiplicity > 0) {
+                    if (nextMultiplicity > 0) {
                         path
                                 .append(" (")
-                                .append(multiplicity)
+                                .append(nextMultiplicity)
                                 .append(")\u200E");
+
+                        nextMultiplicity = -1;
+                    }
+                    if (group.repeats() && multiplicity > 0) {
+                        // Display the multiplicity on the next group (child instance).
+                        nextMultiplicity = multiplicity;
                     }
                     if (index < groups.length) {
                         path.append(" > ");


### PR DESCRIPTION
Cleans up the logic to generate 'breadcrumb' paths to make the path more understandable to users.

<img width="344" alt="screenshot of breadcrumb path" src="https://user-images.githubusercontent.com/2047062/49163680-a55f4f00-f2fb-11e8-884f-b42fa58f23b7.png">

*Dog (jump screen)*

#### Examples

e.g. A

| Screen | Old path | New path |
|---|---|---|
| Friends repeat instance list (jump screen) | Friends | Friends |
| Alice (jump screen) | Friends (1) | Friends > Alice (1) |
| Question about Alice (question view) | Friends (1) > Alice | Friends > Alice (1) |

e.g. B

| Screen | Old path | New path |
|---|---|---|
| Pets repeat instance list (jump screen) | Friends (1) > Pets | Friends > Alice (1) > Pets |
| Dog (jump screen) | Friends (1) > Alice > Pets (1) | Friends > Alice (1) > Pets > Dog (1) |
| Question about Dog (question view) | Friends (1) > Alice > Pets (1) > Dog | Friends > Alice (1) > Pets > Dog (1) |

#### What has been done to verify that this works as intended?

Extensive manual testing with nested-repeats-complex ([XML](https://drive.google.com/open?id=1zOvDEZz6vwQr5IBT91k7MuDMZ-hJDats) / [XLS](https://drive.google.com/open?id=1xVv682pbBMQ_MTZdNnj6aP11jhPp6fT8WQ42oEr7WaA)) (top-level "friends" and "enemies" groups; nested "friends/pets" group).

Navigating in and out of nested repeat groups, adding children, editing names, using the back button, jumping back and forth between the FormEditor and FormHierarchy views.

#### Why is this the best possible solution? Were any other approaches considered?

This solution makes it clear to users where they are in the form, and also makes the path consistent with the names of repeat group instances (e.g. `Alice (1)`).

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

The new paths are more intuitive, but it could potentially disorient existing users who've come to expect a precise string to be displayed (whether from personal experience or from training screenshots).

#### Do we need any specific form for testing your changes? If so, please attach one.

Linked above.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.

None that I can tell.

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)