### PR TITLE
Visible groups in jump screen

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -68,6 +68,12 @@ import timber.log.Timber;
  */
 public class FormHierarchyActivity extends CollectAbstractActivity {
     /**
+     * XML 'appearance' attribute that denotes a group as being displayed
+     * in the hierarchy (rather than invisible).
+     */
+    public static String VISIBLE_GROUP_APPEARANCE = "visible";
+
+    /**
      * The questions and repeats at the current level.
      * Recreated every time {@link #refreshView()} is called.
      */
@@ -321,12 +327,12 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
 
         int event = formController.getEvent(index);
         return event == FormEntryController.EVENT_REPEAT
-                || (event == FormEntryController.EVENT_GROUP && isDisplayableGroup(index));
+                || (event == FormEntryController.EVENT_GROUP && isVisibleGroup(index));
     }
 
-    private boolean isDisplayableGroup(FormIndex groupIndex) {
+    private boolean isVisibleGroup(FormIndex groupIndex) {
         FormController formController = Collect.getInstance().getFormController();
-        return "nested".equals(formController.getAppearanceAttr(groupIndex));
+        return VISIBLE_GROUP_APPEARANCE.equals(formController.getAppearanceAttr(groupIndex));
     }
 
     private String getGroupRef(FormController formController) {
@@ -449,7 +455,7 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
                     case FormEntryController.EVENT_GROUP: {
                         // Only display groups with a specific appearance attribute.
                         FormIndex index = formController.getFormIndex();
-                        if (isDisplayableGroup(index)) {
+                        if (isVisibleGroup(index)) {
                             FormEntryCaption caption = formController.getCaptionPrompt();
                             HierarchyElement groupElement = new HierarchyElement(getLabel(caption), getString(R.string.group_label), null, HierarchyElement.Type.GROUP, caption.getIndex());
                             elementsToDisplay.add(groupElement);

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -266,6 +266,7 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
     private void jumpToHierarchyStartIndex() {
         FormController formController = Collect.getInstance().getFormController();
         FormIndex startIndex = formController.getFormIndex();
+        int event = formController.getEvent();
 
         // If we're not at the first level, we're inside a repeated group so we want to only
         // display everything enclosed within that group.
@@ -276,7 +277,7 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
 
         // If we're currently at a repeat node, record the name of the node and step to the next
         // node to display.
-        if (formController.getEvent() == FormEntryController.EVENT_REPEAT) {
+        if (event == FormEntryController.EVENT_REPEAT || event == FormEntryController.EVENT_GROUP) {
             contextGroupRef = getGroupRef(formController);
             formController.stepToNextEvent(FormController.STEP_INTO_GROUP);
         } else {
@@ -297,11 +298,11 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
                 formController.jumpToIndex(potentialStartIndex);
             }
 
-            int event = formController.getEvent();
+            event = formController.getEvent();
 
             // now test again for repeat. This should be true at this point or we're at the
             // beginning
-            if (event == FormEntryController.EVENT_REPEAT) {
+            if (event == FormEntryController.EVENT_REPEAT || event == FormEntryController.EVENT_GROUP) {
                 contextGroupRef = getGroupRef(formController);
                 formController.stepToNextEvent(FormController.STEP_INTO_GROUP);
             }
@@ -309,7 +310,7 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
     }
 
     /**
-     * Returns true if the event is an enclosing repeat or the start of the form.
+     * Returns true if the event is an enclosing repeat, displayable group, or the start of the form.
      * See {@link FormController#stepToOuterScreenEvent} for more context.
      */
     private boolean isScreenEvent(FormController formController, FormIndex index) {
@@ -319,7 +320,13 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
         }
 
         int event = formController.getEvent(index);
-        return event == FormEntryController.EVENT_REPEAT;
+        return event == FormEntryController.EVENT_REPEAT
+                || (event == FormEntryController.EVENT_GROUP && isDisplayableGroup(index));
+    }
+
+    private boolean isDisplayableGroup(FormIndex groupIndex) {
+        FormController formController = Collect.getInstance().getFormController();
+        return "nested".equals(formController.getAppearanceAttr(groupIndex));
     }
 
     private String getGroupRef(FormController formController) {
@@ -442,7 +449,7 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
                     case FormEntryController.EVENT_GROUP: {
                         // Only display groups with a specific appearance attribute.
                         FormIndex index = formController.getFormIndex();
-                        if ("nested".equals(formController.getAppearanceAttr(index))) {
+                        if (isDisplayableGroup(index)) {
                             FormEntryCaption caption = formController.getCaptionPrompt();
                             HierarchyElement groupElement = new HierarchyElement(getLabel(caption), getString(R.string.group_label), null, HierarchyElement.Type.GROUP, caption.getIndex());
                             elementsToDisplay.add(groupElement);

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -68,12 +68,6 @@ import timber.log.Timber;
  */
 public class FormHierarchyActivity extends CollectAbstractActivity {
     /**
-     * XML 'appearance' attribute that denotes a group as being displayed
-     * in the hierarchy (rather than invisible).
-     */
-    public static String VISIBLE_GROUP_APPEARANCE = "visible";
-
-    /**
      * The questions and repeats at the current level.
      * Recreated every time {@link #refreshView()} is called.
      */
@@ -272,7 +266,6 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
     private void jumpToHierarchyStartIndex() {
         FormController formController = Collect.getInstance().getFormController();
         FormIndex startIndex = formController.getFormIndex();
-        int event = formController.getEvent();
 
         // If we're not at the first level, we're inside a repeated group so we want to only
         // display everything enclosed within that group.
@@ -281,14 +274,14 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
         // Save the index to the screen itself, before potentially moving into it.
         screenIndex = startIndex;
 
-        // If we're currently at a repeat node, record the name of the node and step to the next
+        // If we're currently at a displayable group, record the name of the node and step to the next
         // node to display.
-        if (event == FormEntryController.EVENT_REPEAT || event == FormEntryController.EVENT_GROUP) {
+        if (formController.isDisplayableGroup(startIndex)) {
             contextGroupRef = getGroupRef(formController);
             formController.stepToNextEvent(FormController.STEP_INTO_GROUP);
         } else {
             FormIndex potentialStartIndex = formController.stepIndexOut(startIndex);
-            // Step back until we hit a repeat or the beginning.
+            // Step back until we hit a displayable group or the beginning.
             while (!isScreenEvent(formController, potentialStartIndex)) {
                 potentialStartIndex = formController.stepIndexOut(potentialStartIndex);
             }
@@ -300,15 +293,12 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
                 // is, display the root level from the beginning.
                 formController.jumpToIndex(FormIndex.createBeginningOfFormIndex());
             } else {
-                // otherwise we're at a repeated group
+                // otherwise we're at a displayable group
                 formController.jumpToIndex(potentialStartIndex);
             }
 
-            event = formController.getEvent();
-
-            // now test again for repeat. This should be true at this point or we're at the
-            // beginning
-            if (event == FormEntryController.EVENT_REPEAT || event == FormEntryController.EVENT_GROUP) {
+            // Now test again. This should be true at this point or we're at the beginning.
+            if (formController.isDisplayableGroup(formController.getFormIndex())) {
                 contextGroupRef = getGroupRef(formController);
                 formController.stepToNextEvent(FormController.STEP_INTO_GROUP);
             }
@@ -316,7 +306,7 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
     }
 
     /**
-     * Returns true if the event is an enclosing repeat, displayable group, or the start of the form.
+     * Returns true if the event is a displayable group or the start of the form.
      * See {@link FormController#stepToOuterScreenEvent} for more context.
      */
     private boolean isScreenEvent(FormController formController, FormIndex index) {
@@ -325,14 +315,7 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
             return true;
         }
 
-        int event = formController.getEvent(index);
-        return event == FormEntryController.EVENT_REPEAT
-                || (event == FormEntryController.EVENT_GROUP && isVisibleGroup(index));
-    }
-
-    private boolean isVisibleGroup(FormIndex groupIndex) {
-        FormController formController = Collect.getInstance().getFormController();
-        return VISIBLE_GROUP_APPEARANCE.equals(formController.getAppearanceAttr(groupIndex));
+        return formController.isDisplayableGroup(index);
     }
 
     private String getGroupRef(FormController formController) {
@@ -455,7 +438,7 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
                     case FormEntryController.EVENT_GROUP: {
                         // Only display groups with a specific appearance attribute.
                         FormIndex index = formController.getFormIndex();
-                        if (isVisibleGroup(index)) {
+                        if (formController.isDisplayableGroup(index)) {
                             FormEntryCaption caption = formController.getCaptionPrompt();
                             HierarchyElement groupElement = new HierarchyElement(getLabel(caption), getString(R.string.group_label), null, HierarchyElement.Type.GROUP, caption.getIndex());
                             elementsToDisplay.add(groupElement);

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -440,7 +440,17 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
                         break;
                     }
                     case FormEntryController.EVENT_GROUP: {
-                        // ignore group events
+                        // Only display groups with a specific appearance attribute.
+                        FormIndex index = formController.getFormIndex();
+                        if ("nested".equals(formController.getAppearanceAttr(index))) {
+                            FormEntryCaption caption = formController.getCaptionPrompt();
+                            HierarchyElement groupElement = new HierarchyElement(getLabel(caption), getString(R.string.group_label), null, HierarchyElement.Type.GROUP, caption.getIndex());
+                            elementsToDisplay.add(groupElement);
+
+                            // Skip to the next item outside the group.
+                            formController.forceStepOverGroup();
+                        }
+
                         break;
                     }
                     case FormEntryController.EVENT_PROMPT_NEW_REPEAT: {
@@ -522,6 +532,7 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
                 repeatGroupPickerIndex = index;
                 refreshView();
                 break;
+            case VISIBLE_GROUP:
             case REPEAT_INSTANCE:
                 // Hide the picker.
                 repeatGroupPickerIndex = null;

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -440,7 +440,7 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
                         FormIndex index = formController.getFormIndex();
                         if (formController.isDisplayableGroup(index)) {
                             FormEntryCaption caption = formController.getCaptionPrompt();
-                            HierarchyElement groupElement = new HierarchyElement(getLabel(caption), getString(R.string.group_label), null, HierarchyElement.Type.GROUP, caption.getIndex());
+                            HierarchyElement groupElement = new HierarchyElement(getLabel(caption), getString(R.string.group_label), null, HierarchyElement.Type.VISIBLE_GROUP, caption.getIndex());
                             elementsToDisplay.add(groupElement);
 
                             // Skip to the next item outside the group.

--- a/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
+++ b/collect_app/src/main/java/org/odk/collect/android/activities/FormHierarchyActivity.java
@@ -422,7 +422,7 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
                 }
 
                 switch (event) {
-                    case FormEntryController.EVENT_QUESTION:
+                    case FormEntryController.EVENT_QUESTION: {
                         if (shouldShowRepeatGroupPicker()) {
                             break;
                         }
@@ -438,14 +438,17 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
                                             HierarchyElement.Type.QUESTION, fp.getIndex()));
                         }
                         break;
-                    case FormEntryController.EVENT_GROUP:
+                    }
+                    case FormEntryController.EVENT_GROUP: {
                         // ignore group events
                         break;
-                    case FormEntryController.EVENT_PROMPT_NEW_REPEAT:
+                    }
+                    case FormEntryController.EVENT_PROMPT_NEW_REPEAT: {
                         // this would display the 'add new repeat' dialog
                         // ignore it.
                         break;
-                    case FormEntryController.EVENT_REPEAT:
+                    }
+                    case FormEntryController.EVENT_REPEAT: {
                         FormEntryCaption fc = formController.getCaptionPrompt();
                         // push this repeat onto the stack.
                         repeatGroupRef = currentRef;
@@ -489,6 +492,7 @@ public class FormHierarchyActivity extends CollectAbstractActivity {
                         }
 
                         break;
+                    }
                 }
                 event =
                         formController.stepToNextEvent(FormController.STEP_INTO_GROUP);

--- a/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
@@ -373,14 +373,7 @@ public class FormController {
     }
 
     private boolean repeatIsFieldList(FormIndex index) {
-        // if this isn't a group, return right away
-        IFormElement element = formEntryController.getModel().getForm().getChild(index);
-        if (!(element instanceof GroupDef)) {
-            return false;
-        }
-
-        GroupDef gd = (GroupDef) element; // exceptions?
-        return ODKView.FIELD_LIST.equalsIgnoreCase(gd.getAppearanceAttr());
+        return groupIsFieldList(index);
     }
 
     /**

--- a/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
@@ -86,6 +86,12 @@ public class FormController {
     private static final String AUDIT = "audit";
     public static final String AUDIT_FILE_NAME = "audit.csv";
 
+    /**
+     * XML 'appearance' attribute that denotes a group as being displayed
+     * in the hierarchy (rather than invisible).
+     */
+    public static String VISIBLE_GROUP_APPEARANCE = "visible";
+
     /*
      * Store the timerLogger object with the form controller state
      */
@@ -648,29 +654,41 @@ public class FormController {
     }
 
     /**
-     * Move the current form index to the index of the first enclosing repeat
+     * Move the current form index to the index of the first displayable group
+     * (that is, a repeatable group or a visible group),
      * or to the start of the form.
      */
     public int stepToOuterScreenEvent() {
-        FormIndex index = stepIndexOut(getFormIndex());
-        int currentEvent = getEvent();
+        FormIndex index = getFormIndex();
 
-        // Step out of any group indexes that are present.
+        // Step out once to begin with if we're coming from a question.
+        if (getEvent() == FormEntryController.EVENT_QUESTION) {
+            index = stepIndexOut(index);
+        }
+
+        // Save where we started from.
+        FormIndex startIndex = index;
+
+        // Step out once more no matter what.
+        index = stepIndexOut(index);
+
+        // Step out of any group indexes that are present, unless they're visible.
         while (index != null
-                && getEvent(index) == FormEntryController.EVENT_GROUP) {
+                && getEvent(index) == FormEntryController.EVENT_GROUP
+                && !isDisplayableGroup(index)) {
             index = stepIndexOut(index);
         }
 
         if (index == null) {
             jumpToIndex(FormIndex.createBeginningOfFormIndex());
         } else {
-            if (currentEvent == FormEntryController.EVENT_REPEAT) {
-                // We were at a repeat, so stepping back brought us to then previous level
+            if (isDisplayableGroup(startIndex)) {
+                // We were at a displayable group, so stepping back brought us to the previous level
                 jumpToIndex(index);
             } else {
                 // We were at a question, so stepping back brought us to either:
-                // The beginning. or The start of a repeat. So we need to step
-                // out again to go passed the repeat.
+                // The beginning, or the start of a displayable group. So we need to step
+                // out again to go past the group.
                 index = stepIndexOut(index);
                 if (index == null) {
                     jumpToIndex(FormIndex.createBeginningOfFormIndex());
@@ -680,6 +698,15 @@ public class FormController {
             }
         }
         return getEvent();
+    }
+
+    /**
+     * Returns true if the index is either a repeatable group or a visible group.
+     */
+    public boolean isDisplayableGroup(FormIndex index) {
+        return getEvent(index) == FormEntryController.EVENT_REPEAT ||
+                (getEvent(index) == FormEntryController.EVENT_GROUP
+                && VISIBLE_GROUP_APPEARANCE.equals(getAppearanceAttr(index)));
     }
 
     public static class FailedConstraint {

--- a/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
@@ -516,6 +516,19 @@ public class FormController {
     }
 
     /**
+     * Same as {@link #stepToNextEvent stepToNextEvent(false)}, but ignores question types.
+     * It always steps over the group.
+     */
+    public int forceStepOverGroup() {
+        if ((getEvent() == FormEntryController.EVENT_GROUP
+                || getEvent() == FormEntryController.EVENT_REPEAT)) {
+            return stepOverGroup();
+        } else {
+            return formEntryController.stepToNextEvent();
+        }
+    }
+
+    /**
      * If using a view like HierarchyView that doesn't support multi-question per screen, step over
      * the group represented by the FormIndex.
      */

--- a/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
@@ -14,6 +14,7 @@
 
 package org.odk.collect.android.logic;
 
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import com.google.android.gms.analytics.HitBuilders;
@@ -368,12 +369,24 @@ public class FormController {
             return false;
         }
 
-        GroupDef gd = (GroupDef) element; // exceptions?
-        return ODKView.FIELD_LIST.equalsIgnoreCase(gd.getAppearanceAttr());
+        return ODKView.FIELD_LIST.equalsIgnoreCase(element.getAppearanceAttr());
     }
 
     private boolean repeatIsFieldList(FormIndex index) {
         return groupIsFieldList(index);
+    }
+
+    /**
+     * Returns the `appearance` attribute of the current index, if any.
+     */
+    public String getAppearanceAttr(@NonNull FormIndex index) {
+        // FormDef can't have an appearance, it would throw an exception.
+        if (index.isBeginningOfFormIndex()) {
+            return null;
+        }
+
+        IFormElement element = formEntryController.getModel().getForm().getChild(index);
+        return element.getAppearanceAttr();
     }
 
     /**

--- a/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
@@ -90,7 +90,7 @@ public class FormController {
      * XML 'appearance' attribute that denotes a group as being displayed
      * in the hierarchy (rather than invisible).
      */
-    public static String VISIBLE_GROUP_APPEARANCE = "hierarchy-visible";
+    public static final String VISIBLE_GROUP_APPEARANCE = "hierarchy-visible";
 
     /*
      * Store the timerLogger object with the form controller state
@@ -526,8 +526,8 @@ public class FormController {
      * It always steps over the group.
      */
     public int forceStepOverGroup() {
-        if ((getEvent() == FormEntryController.EVENT_GROUP
-                || getEvent() == FormEntryController.EVENT_REPEAT)) {
+        if (getEvent() == FormEntryController.EVENT_GROUP
+                || getEvent() == FormEntryController.EVENT_REPEAT) {
             return stepOverGroup();
         } else {
             return formEntryController.stepToNextEvent();

--- a/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
@@ -90,7 +90,7 @@ public class FormController {
      * XML 'appearance' attribute that denotes a group as being displayed
      * in the hierarchy (rather than invisible).
      */
-    public static String VISIBLE_GROUP_APPEARANCE = "visible";
+    public static String VISIBLE_GROUP_APPEARANCE = "hierarchy-visible";
 
     /*
      * Store the timerLogger object with the form controller state

--- a/collect_app/src/main/java/org/odk/collect/android/logic/HierarchyElement.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/HierarchyElement.java
@@ -102,6 +102,7 @@ public class HierarchyElement {
      */
     public enum Type {
         QUESTION,
+        VISIBLE_GROUP,
         REPEATABLE_GROUP,
         REPEAT_INSTANCE
     }

--- a/collect_app/src/main/res/values/strings.xml
+++ b/collect_app/src/main/res/values/strings.xml
@@ -116,6 +116,7 @@
     <string name="quit_application">Exit %s</string>
     <string name="quit_entry">Save Form and Exit</string>
     <string name="refresh">Refresh</string>
+    <string name="group_label">Group</string>
     <string name="repeatable_group_label">Repeatable Group</string>
     <string name="replace_barcode">Replace Barcode</string>
     <string name="required_answer_error">Sorry, this response is required!</string>


### PR DESCRIPTION
Adds the ability to designate groups as "visible" so they show up on the jump screen. You can then click on the group to see its children, similar to how you can view repeat instances.

To make a group visible, simply add an `appearance` trait like so:

```xml
<group appearance="hierarchy-visible">
    ...
</group>
```

Normally groups are invisible to the user, but with this new appearance, they become a selectable item in the jump screen. All children of the group are then hidden from the main screen, and will be shown on the inner screen instead:

<img width="323" alt="screenshot of main jump screen" src="https://user-images.githubusercontent.com/2047062/49188404-a4004780-f338-11e8-8288-01089276fb95.png">

*Main jump screen*

<img width="323" alt="screenshot of inner group" src="https://user-images.githubusercontent.com/2047062/49188407-a5ca0b00-f338-11e8-9d02-5e64a9f91212.png">

*Inside the "Date and time widgets" group*

#### What has been done to verify that this works as intended?

Extensive manual testing with visible_groups ([XML](https://drive.google.com/open?id=1JabZFs4NdFrLSjkqdDtXc2EnJWuK_IoD) / [XLS](https://drive.google.com/open?id=1DwXUPtcNly8mPRPAIreIhq7ME_D3X0W7gllCmSAX2g8)) (grouped widgets; the "Date and time widgets" group is marked as visible, and has a nested "Inner group" that's also visible).

Navigating in and out of nested groups, using the back button, jumping back and forth between the FormEditor and FormHierarchy views.

#### Why is this the best possible solution? Were any other approaches considered?

Allowing groups to be visible gives more power to form designers who may want to prevent certain groups from cluttering the jump screen. It also makes it easier to focus on the questions within those groups if desired.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Users will be unaffected unless they use forms that specify this new group appearance.

Regression risks include any logic that previously assumed that regular groups could never be "screen events". There were several methods that checked for **repeatable** groups, which now also need to check for **visible** groups as well. All of the logic I could find has been updated accordingly.

#### Do we need any specific form for testing your changes? If so, please attach one.

Linked above.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.

Yes, documenting the new appearance attribute [here](http://xlsform.org/en/#appearance). TODO

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)