### PR TITLE
Remembering previously entered values (auto-fill)

### DIFF
--- a/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
@@ -63,6 +63,7 @@ import java.util.List;
 import timber.log.Timber;
 
 import static org.odk.collect.android.utilities.ApplicationConstants.Namespaces.XML_OPENDATAKIT_NAMESPACE;
+import static org.odk.collect.android.utilities.FileUtils.LAST_SAVED_FILENAME;
 
 /**
  * This class is a wrapper for Javarosa's FormEntryController. In theory, if you wanted to replace
@@ -88,9 +89,6 @@ public class FormController {
      */
     private static final String AUDIT = "audit";
     public static final String AUDIT_FILE_NAME = "audit.csv";
-
-    /** Filename of the last-saved instance data. */
-    public static final String LAST_SAVED_FILENAME = "last-saved.xml";
 
     /*
      * Store the auditEventLogger object with the form controller state

--- a/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
+++ b/collect_app/src/main/java/org/odk/collect/android/logic/FormController.java
@@ -89,6 +89,9 @@ public class FormController {
     private static final String AUDIT = "audit";
     public static final String AUDIT_FILE_NAME = "audit.csv";
 
+    /** Filename of the last-saved instance data. */
+    public static final String LAST_SAVED_FILENAME = "last-saved.xml";
+
     /*
      * Store the auditEventLogger object with the form controller state
      */
@@ -168,6 +171,11 @@ public class FormController {
     @Nullable
     public String getAbsoluteInstancePath() {
         return instanceFile != null ? instanceFile.getAbsolutePath() : null;
+    }
+
+    @Nullable
+    public String getLastSavedPath() {
+        return mediaFolder != null ? mediaFolder.getAbsolutePath() + File.separator + LAST_SAVED_FILENAME : null;
     }
 
     public void setIndexWaitingForData(FormIndex index) {

--- a/collect_app/src/main/java/org/odk/collect/android/provider/FormsProvider.java
+++ b/collect_app/src/main/java/org/odk/collect/android/provider/FormsProvider.java
@@ -44,6 +44,7 @@ import java.util.Map;
 import timber.log.Timber;
 
 import static org.odk.collect.android.database.helpers.FormsDatabaseHelper.FORMS_TABLE_NAME;
+import static org.odk.collect.android.utilities.FileUtils.MEDIA_SUFFIX;
 import static org.odk.collect.android.utilities.PermissionUtils.areStoragePermissionsGranted;
 
 public class FormsProvider extends ContentProvider {
@@ -214,7 +215,7 @@ public class FormsProvider extends ContentProvider {
             if (!values.containsKey(FormsColumns.FORM_MEDIA_PATH)) {
                 String pathNoExtension = filePath.substring(0,
                         filePath.lastIndexOf('.'));
-                String mediaPath = pathNoExtension + "-media";
+                String mediaPath = pathNoExtension + MEDIA_SUFFIX;
                 values.put(FormsColumns.FORM_MEDIA_PATH, mediaPath);
             }
 

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/FormLoaderTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/FormLoaderTask.java
@@ -61,7 +61,7 @@ import java.util.Map;
 import au.com.bytecode.opencsv.CSVReader;
 import timber.log.Timber;
 
-import static org.odk.collect.android.logic.FormController.LAST_SAVED_FILENAME;
+import static org.odk.collect.android.utilities.FileUtils.LAST_SAVED_FILENAME;
 
 /**
  * Background task for loading a form.

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/FormLoaderTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/FormLoaderTask.java
@@ -126,8 +126,8 @@ public class FormLoaderTask extends AsyncTask<String, String, FormLoaderTask.FEC
         final File formXml = new File(formPath);
 
         // set paths to /sdcard/odk/forms/formfilename-media/
-        final String formFileName = getFormFileName(formXml);
-        final File formMediaDir = getFormMediaDir(formXml);
+        final String formFileName = FileUtils.getFormFileName(formXml);
+        final File formMediaDir = FileUtils.getFormMediaDir(formXml);
 
         final ReferenceManager referenceManager = ReferenceManager.instance();
 
@@ -215,15 +215,6 @@ public class FormLoaderTask extends AsyncTask<String, String, FormLoaderTask.FEC
         return data;
     }
 
-    private String getFormFileName(File formXml) {
-        return formXml.getName().substring(0, formXml.getName().lastIndexOf("."));
-    }
-
-    private File getFormMediaDir(File formXml) {
-        final String formFileName = getFormFileName(formXml);
-        return new File(formXml.getParent(), formFileName + "-media");
-    }
-
     private void addSessionRootTranslators(String formFileName, ReferenceManager referenceManager, String... hostStrings) {
         // Set jr://... to point to /sdcard/odk/forms/filename-media/
         final String translatedPrefix = String.format("jr://file/forms/%s-media/", formFileName);
@@ -242,8 +233,7 @@ public class FormLoaderTask extends AsyncTask<String, String, FormLoaderTask.FEC
         }
 
         // Get the last-saved instance, if it exists.
-        String lastSavedPath = getFormMediaDir(formXml).getAbsoluteFile() + File.separator + LAST_SAVED_FILENAME;
-        File lastSavedFile = new File(lastSavedPath);
+        File lastSavedFile = FileUtils.getLastSavedFile(formXml);
         String lastSavedSrc = lastSavedFile.exists() ? "jr://file/" + LAST_SAVED_FILENAME : null;
 
         FileInputStream fis = null;

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/FormLoaderTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/FormLoaderTask.java
@@ -232,16 +232,13 @@ public class FormLoaderTask extends AsyncTask<String, String, FormLoaderTask.FEC
             return formDefFromCache;
         }
 
-        // Get the last-saved instance, if it exists.
-        File lastSavedFile = FileUtils.getLastSavedFile(formXml);
-        String lastSavedSrc = lastSavedFile.exists() ? "jr://file/" + LAST_SAVED_FILENAME : null;
-
         FileInputStream fis = null;
         // no binary, read from xml
         try {
             Timber.i("Attempting to load from: %s", formXml.getAbsolutePath());
             final long start = System.currentTimeMillis();
             fis = new FileInputStream(formXml);
+            String lastSavedSrc = FileUtils.getLastSavedSrcIfExists(formXml);
             FormDef formDefFromXml = XFormUtils.getFormFromInputStream(fis, lastSavedSrc);
             if (formDefFromXml == null) {
                 errorMsg = "Error reading XForm file";

--- a/collect_app/src/main/java/org/odk/collect/android/tasks/SaveToDiskTask.java
+++ b/collect_app/src/main/java/org/odk/collect/android/tasks/SaveToDiskTask.java
@@ -270,9 +270,13 @@ public class SaveToDiskTask extends AsyncTask<Void, String, SaveResult> {
 
         writeFile(payload, instancePath);
 
+        // Write SMS data
         final ByteArrayPayload payloadSms = formController.getFilledInFormSMS();
-        // Write SMS to card
         writeFile(payloadSms, getSmsInstancePath(instancePath));
+
+        // Write last-saved instance
+        String lastSavedPath = formController.getLastSavedPath();
+        writeFile(payload, lastSavedPath);
 
         // update the uri. We have exported the reloadable instance, so update status...
         // Since we saved a reloadable instance, it is flagged as re-openable so that if any error

--- a/collect_app/src/main/java/org/odk/collect/android/upload/InstanceGoogleSheetsUploader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/upload/InstanceGoogleSheetsUploader.java
@@ -297,10 +297,8 @@ public class InstanceGoogleSheetsUploader extends InstanceUploader {
     private TreeElement getInstanceElement(String formFilePath, File instanceFile) throws UploadException {
         FormDef formDef;
 
-        // Get the last-saved instance, if it exists.
         File formXml = new File(formFilePath);
-        File lastSavedFile = FileUtils.getLastSavedFile(formXml);
-        String lastSavedSrc = lastSavedFile.exists() ? "jr://file/" + LAST_SAVED_FILENAME : null;
+        String lastSavedSrc = FileUtils.getLastSavedSrcIfExists(formXml);
 
         try {
             formDef = XFormUtils.getFormFromInputStream(new FileInputStream(formXml), lastSavedSrc);

--- a/collect_app/src/main/java/org/odk/collect/android/upload/InstanceGoogleSheetsUploader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/upload/InstanceGoogleSheetsUploader.java
@@ -43,6 +43,7 @@ import org.odk.collect.android.exception.MultipleFoldersFoundException;
 import org.odk.collect.android.preferences.GeneralSharedPreferences;
 import org.odk.collect.android.preferences.GeneralKeys;
 import org.odk.collect.android.tasks.FormLoaderTask;
+import org.odk.collect.android.utilities.FileUtils;
 import org.odk.collect.android.utilities.UrlUtils;
 import org.odk.collect.android.utilities.gdrive.DriveHelper;
 import org.odk.collect.android.utilities.gdrive.GoogleAccountsManager;
@@ -64,6 +65,7 @@ import java.util.regex.Pattern;
 import timber.log.Timber;
 
 import static org.odk.collect.android.logic.FormController.INSTANCE_ID;
+import static org.odk.collect.android.logic.FormController.LAST_SAVED_FILENAME;
 
 public class InstanceGoogleSheetsUploader extends InstanceUploader {
     private static final String PARENT_KEY = "PARENT_KEY";
@@ -294,8 +296,14 @@ public class InstanceGoogleSheetsUploader extends InstanceUploader {
 
     private TreeElement getInstanceElement(String formFilePath, File instanceFile) throws UploadException {
         FormDef formDef;
+
+        // Get the last-saved instance, if it exists.
+        File formXml = new File(formFilePath);
+        File lastSavedFile = FileUtils.getLastSavedFile(formXml);
+        String lastSavedSrc = lastSavedFile.exists() ? "jr://file/" + LAST_SAVED_FILENAME : null;
+
         try {
-            formDef = XFormUtils.getFormFromInputStream(new FileInputStream(new File(formFilePath)));
+            formDef = XFormUtils.getFormFromInputStream(new FileInputStream(formXml), lastSavedSrc);
         } catch (FileNotFoundException e) {
             throw new UploadException(e);
         }

--- a/collect_app/src/main/java/org/odk/collect/android/upload/InstanceGoogleSheetsUploader.java
+++ b/collect_app/src/main/java/org/odk/collect/android/upload/InstanceGoogleSheetsUploader.java
@@ -65,7 +65,7 @@ import java.util.regex.Pattern;
 import timber.log.Timber;
 
 import static org.odk.collect.android.logic.FormController.INSTANCE_ID;
-import static org.odk.collect.android.logic.FormController.LAST_SAVED_FILENAME;
+import static org.odk.collect.android.utilities.FileUtils.LAST_SAVED_FILENAME;
 
 public class InstanceGoogleSheetsUploader extends InstanceUploader {
     private static final String PARENT_KEY = "PARENT_KEY";

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
@@ -23,6 +23,7 @@ import android.graphics.BitmapFactory;
 import android.net.Uri;
 import android.os.Build;
 
+import android.support.annotation.Nullable;
 import org.apache.commons.io.IOUtils;
 import org.javarosa.xform.parse.XFormParser;
 import org.kxml2.kdom.Document;
@@ -426,6 +427,12 @@ public class FileUtils {
 
     public static File getLastSavedFile(File formXml) {
         return new File(getFormMediaDir(formXml), LAST_SAVED_FILENAME);
+    }
+
+    @Nullable
+    public static String getLastSavedSrcIfExists(File formXml) {
+        File lastSavedFile = getLastSavedFile(formXml);
+        return lastSavedFile.exists() ? "jr://file/" + LAST_SAVED_FILENAME : null;
     }
 
     /**

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
@@ -51,8 +51,6 @@ import java.util.Locale;
 
 import timber.log.Timber;
 
-import static org.odk.collect.android.logic.FormController.LAST_SAVED_FILENAME;
-
 /**
  * Static methods used for common file operations.
  *
@@ -69,6 +67,10 @@ public class FileUtils {
     public static final String BASE64_RSA_PUBLIC_KEY = "base64RsaPublicKey";
     public static final String AUTO_DELETE = "autoDelete";
     public static final String AUTO_SEND = "autoSend";
+
+    /** Filename of the last-saved instance data. */
+    public static final String LAST_SAVED_FILENAME = "last-saved.xml";
+
     static int bufSize = 16 * 1024; // May be set by unit test
 
     private FileUtils() {

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
@@ -68,6 +68,9 @@ public class FileUtils {
     public static final String AUTO_DELETE = "autoDelete";
     public static final String AUTO_SEND = "autoSend";
 
+    /** Suffix for the form media directory. */
+    public static final String MEDIA_SUFFIX = "-media";
+
     /** Filename of the last-saved instance data. */
     public static final String LAST_SAVED_FILENAME = "last-saved.xml";
 
@@ -413,12 +416,12 @@ public class FileUtils {
     }
 
     public static String constructMediaPath(String formFilePath) {
-        return getFormFileName(formFilePath) + "-media";
+        return getFormFileName(formFilePath) + MEDIA_SUFFIX;
     }
 
     public static File getFormMediaDir(File formXml) {
         final String formFileName = getFormFileName(formXml);
-        return new File(formXml.getParent(), formFileName + "-media");
+        return new File(formXml.getParent(), formFileName + MEDIA_SUFFIX);
     }
 
     public static File getLastSavedFile(File formXml) {

--- a/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
+++ b/collect_app/src/main/java/org/odk/collect/android/utilities/FileUtils.java
@@ -51,6 +51,8 @@ import java.util.Locale;
 
 import timber.log.Timber;
 
+import static org.odk.collect.android.logic.FormController.LAST_SAVED_FILENAME;
+
 /**
  * Static methods used for common file operations.
  *
@@ -400,9 +402,25 @@ public class FileUtils {
         }
     }
 
+    public static String getFormFileName(File formXml) {
+        return getFormFileName(formXml.getName());
+    }
+
+    public static String getFormFileName(String formFilePath) {
+        return formFilePath.substring(0, formFilePath.lastIndexOf('.'));
+    }
+
     public static String constructMediaPath(String formFilePath) {
-        String pathNoExtension = formFilePath.substring(0, formFilePath.lastIndexOf('.'));
-        return pathNoExtension + "-media";
+        return getFormFileName(formFilePath) + "-media";
+    }
+
+    public static File getFormMediaDir(File formXml) {
+        final String formFileName = getFormFileName(formXml);
+        return new File(formXml.getParent(), formFileName + "-media");
+    }
+
+    public static File getLastSavedFile(File formXml) {
+        return new File(getFormMediaDir(formXml), LAST_SAVED_FILENAME);
     }
 
     /**

--- a/collect_app/src/main/java/org/odk/collect/android/widgets/OSMWidget.java
+++ b/collect_app/src/main/java/org/odk/collect/android/widgets/OSMWidget.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.odk.collect.android.utilities.ApplicationConstants.RequestCodes;
+import static org.odk.collect.android.utilities.FileUtils.MEDIA_SUFFIX;
 
 /**
  * Widget that allows the user to launch OpenMapKit to get an OSM Feature with a
@@ -70,7 +71,7 @@ public class OSMWidget extends QuestionWidget implements BinaryWidget {
          * has the substring of the file name in it, so I extract the file name
          * from here. Awkward...
          */
-        formFileName = formController.getMediaFolder().getName().split("-media")[0];
+        formFileName = formController.getMediaFolder().getName().split(MEDIA_SUFFIX)[0];
 
         instanceDirectory = formController.getInstanceFile().getParent();
         instanceId = formController.getSubmissionMetadata().instanceId;


### PR DESCRIPTION
Closes `https://github.com/opendatakit/roadmap/issues/30 TODO link in real PR`

Depends on https://github.com/cooperka/javarosa/pull/1 [TODO: update link in real PR]

Allows form designers to refer to the last-saved instance of this particular form in order to retrieve answers from it. Simply add an external instance to your form:

```xml
<instance id="last-saved" src="jr://instance/last-saved"/>
```

The instance `id` can be anything you want.

Then you can access the external data as usual, for example:

```xml
<setvalue event="xforms-ready" ref="/data/foo" value="instance('last-saved')/data/foo"/>
```

#### What has been done to verify that this works as intended?

Extensive testing with [autoFillTest.xml](https://github.com/cooperka/collect/files/2842612/autoFillTest.xml.txt): filling blank forms, saving forms, filling new blank forms, finalizing, exiting without saving, etc.

#### Why is this the best possible solution? Were any other approaches considered?

See extensive discussion at `https://github.com/opendatakit/roadmap/issues/30 TODO link in real PR`. The result of the discussion there was this approach. It makes use of existing logic to accomplish this feature without needing too much new code.

Collect caches the last-saved instance to the form's media directory `formName-media/last-saved.xml` on each save. This file will stay around even if the original saved instance is lost, which is probably what users would expect. The form's media directory is deleted when the blank form is deleted from the device, which is also probably what users would expect.

When parsing new FormDefs, `lastSavedSrc` will be passed to JavaRosa as either `"jr://file/last-saved.xml"` or `null` if no file exists because the form has never been saved. A `null` value means no instance `src` is provided, meaning the instance will be treated as **internal** instead of **external**. The internal `<instance id="last-saved"/>` has no children and thus will provide empty values for anything referring to it.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

Form designers will be able to designate questions as "auto-filled" based on the last-saved value for that particular question. I don't anticipate much regression risk here since the old logic isn't significantly modified.

#### Do we need any specific form for testing your changes? If so, please attach one.

Linked above.

#### Does this change require updates to documentation? If so, please file an issue [here]( https://github.com/opendatakit/docs/issues/new) and include the link below.

Yes [TODO file issue].

It will also require an update to ODK Build if they want to support this [TODO file issue].

#### Before submitting this PR, please make sure you have:
- [ ] run `./gradlew checkAll` and confirmed all checks still pass OR confirm CircleCI build passes and run `./gradlew connectedDebugAndroidTest` locally.
- [x] verified that any code or assets from external sources are properly credited in comments and/or in the [about file](https://github.com/opendatakit/collect/blob/master/collect_app/src/main/assets/open_source_licenses.html).
- [x] verified that any new UI elements use theme colors. [UI Components Style guidelines](https://github.com/opendatakit/collect/blob/master/CONTRIBUTING.md#ui-components-style-guidelines)
